### PR TITLE
Fix zero length splines

### DIFF
--- a/slcgen.py
+++ b/slcgen.py
@@ -126,9 +126,14 @@ class GlyphProxy:
 
 	def rawpoly(self, *points):
 		pen = self.glyph.glyphPen(replace=False)
-		pen.moveTo((round(points[0][0]), round(points[0][1])))
+		coords = (round(points[0][0]), round(points[0][1]))
+		pen.moveTo(coords[0], coords[1])
 		for p in points[1:]:
-			pen.lineTo((round(p[0]), round(p[1])))
+			coords_new = (round(p[0]), round(p[1]))
+			if coords_new == coords:
+				continue
+			coords = coords_new
+			pen.lineTo(coords)
 		pen.closePath()
 		self.glyph.simplify()
 		return self


### PR DESCRIPTION
**[why]**
With some settings the points we calculate on a polygon will be - after rounding have the same coordinates and thus a line with zero lenght.

This creates on `glyph.simplify()` an error:
```
NaN value in spline creation
```

**[how]**
Check after(!) rounding if we moved the pen at all, and if not ignore the point.

Fixes: #2